### PR TITLE
Feat: resume 기능 완성 및 관련 entity 수정

### DIFF
--- a/src/dto/recruit.dto.ts
+++ b/src/dto/recruit.dto.ts
@@ -3,12 +3,12 @@ export default class RecruitDto {
   recruitName: string;
   recruitStart: Date;
   recruitEnd: Date;
-  countryId: number;
-  location: string;
-  industryId: number;
+  countryId?: number;
+  location?: string;
+  industryId?: number;
   descriptions: string;
   payType: string;
   payAmount: number;
-  photos: string;
-  certifications: string;
+  photos?: string;
+  certifications?: string;
 }

--- a/src/dto/resume.dto.ts
+++ b/src/dto/resume.dto.ts
@@ -1,0 +1,15 @@
+import User from 'src/entity/user.entity';
+
+export default class ResumeDto {
+  resumeId?: number;
+  person: User;
+  catchphrase: string;
+  introduction: string;
+  desiredIndustry?: number[];
+  desiredCountry?: number[];
+  desiredLocation?: string;
+  desiredPay?: string;
+  public: boolean;
+  career?: number[];
+  language?: number[];
+}

--- a/src/entity/career.entity.ts
+++ b/src/entity/career.entity.ts
@@ -2,10 +2,12 @@ import {
   BaseEntity,
   Column,
   Entity,
+  ManyToMany,
   ManyToOne,
   PrimaryGeneratedColumn,
 } from 'typeorm';
 import Industry from './industry.entity';
+import Resume from './resume.entity';
 import User from './user.entity';
 
 @Entity()
@@ -16,13 +18,22 @@ export default class Career extends BaseEntity {
   @Column({ nullable: false })
   careerName: string;
 
-  @Column()
+  @Column({ nullable: true })
   careerPeriod: number;
 
-  @Column()
+  @Column({ nullable: true })
   careerEvidence: string;
 
-  @ManyToOne(() => User, (user) => user.id, { nullable: false, cascade: true })
+  @ManyToMany(() => Resume, (resume) => resume.id, {
+    nullable: false,
+    cascade: true,
+  })
+  resumes: Resume[];
+
+  @ManyToOne(() => User, (person) => person.id, {
+    nullable: false,
+    cascade: true,
+  })
   person: User;
 
   @ManyToOne(() => Industry, (industry) => industry.id, {

--- a/src/entity/country.entity.ts
+++ b/src/entity/country.entity.ts
@@ -1,4 +1,11 @@
-import { BaseEntity, Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+import {
+  BaseEntity,
+  Column,
+  Entity,
+  ManyToMany,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import Resume from './resume.entity';
 
 @Entity()
 export default class Country extends BaseEntity {
@@ -7,4 +14,10 @@ export default class Country extends BaseEntity {
 
   @Column({ nullable: false, unique: true })
   countryName: string;
+
+  @ManyToMany(() => Resume, (resume) => resume.id, {
+    cascade: true,
+    nullable: true,
+  })
+  resumes: Resume[];
 }

--- a/src/entity/industry.entity.ts
+++ b/src/entity/industry.entity.ts
@@ -1,4 +1,11 @@
-import { BaseEntity, Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+import {
+  BaseEntity,
+  Column,
+  Entity,
+  ManyToMany,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import Resume from './resume.entity';
 
 @Entity()
 export default class Industry extends BaseEntity {
@@ -7,4 +14,10 @@ export default class Industry extends BaseEntity {
 
   @Column({ nullable: false, unique: true })
   industryName: string;
+
+  @ManyToMany(() => Resume, (resume) => resume.id, {
+    cascade: true,
+    nullable: true,
+  })
+  resumes: Industry;
 }

--- a/src/entity/language.entity.ts
+++ b/src/entity/language.entity.ts
@@ -2,9 +2,11 @@ import {
   BaseEntity,
   Column,
   Entity,
+  ManyToMany,
   ManyToOne,
   PrimaryGeneratedColumn,
 } from 'typeorm';
+import Resume from './resume.entity';
 import User from './user.entity';
 
 @Entity()
@@ -15,7 +17,16 @@ export default class Language extends BaseEntity {
   @Column()
   language: string;
 
-  @ManyToOne(() => User, (user) => user.id, { nullable: false, cascade: true })
+  @ManyToMany(() => Resume, (resume) => resume.id, {
+    nullable: false,
+    cascade: true,
+  })
+  resumes: Resume[];
+
+  @ManyToOne(() => User, (person) => person.id, {
+    nullable: false,
+    cascade: true,
+  })
   person: User;
 
   @Column()

--- a/src/entity/resume.entity.ts
+++ b/src/entity/resume.entity.ts
@@ -4,10 +4,14 @@ import {
   Entity,
   ManyToMany,
   ManyToOne,
+  OneToMany,
   PrimaryGeneratedColumn,
+  JoinTable,
 } from 'typeorm';
+import Career from './career.entity';
 import Country from './country.entity';
 import Industry from './industry.entity';
+import Language from './language.entity';
 import User from './user.entity';
 
 @Entity()
@@ -21,16 +25,37 @@ export default class Resume extends BaseEntity {
   @Column()
   catchPhrase: string;
 
+  @Column()
+  introduction: string;
+
   @ManyToMany(() => Industry, (industry) => industry.id, {
     cascade: true,
+    nullable: true,
   })
+  @JoinTable()
   desiredIndustry: Industry[];
 
   @ManyToMany(() => Country, (country) => country.id, {
     cascade: true,
+    nullable: true,
   })
+  @JoinTable()
   desiredCountry: Country[];
 
-  @Column()
+  @Column({ nullable: true })
   desiredLocation: string;
+
+  @Column({ nullable: true })
+  desiredPay: string;
+
+  @Column({ default: false })
+  public: boolean;
+
+  @ManyToMany(() => Career, (career) => career.id, { cascade: true })
+  @JoinTable()
+  career: Career[];
+
+  @ManyToMany(() => Language, (language) => language.id, { cascade: true })
+  @JoinTable()
+  language: Language[];
 }

--- a/src/lib/dataSourse.ts
+++ b/src/lib/dataSourse.ts
@@ -1,3 +1,9 @@
+import Career from 'src/entity/career.entity';
+import Country from 'src/entity/country.entity';
+import Industry from 'src/entity/industry.entity';
+import Language from 'src/entity/language.entity';
+import Resume from 'src/entity/resume.entity';
+import User from 'src/entity/user.entity';
 import { DataSource } from 'typeorm';
 import { SnakeNamingStrategy } from 'typeorm-naming-strategies';
 
@@ -12,7 +18,15 @@ export const dataSource = new DataSource({
   database: DB_DATABASE,
   synchronize: true, // 배포 시에 false로
   logging: true,
-  entities: [`${__dirname}/../entity/*.entity.{js,ts}`],
+  entities: [
+    Resume,
+    Country,
+    Industry,
+    User,
+    Career,
+    Language,
+    `${__dirname}/../entity/*.entity.{js,ts}`,
+  ],
   subscribers: [],
   migrations: [],
   namingStrategy: new SnakeNamingStrategy(),

--- a/src/my/my.controller.ts
+++ b/src/my/my.controller.ts
@@ -1,6 +1,7 @@
 import {
   Body,
   Controller,
+  Delete,
   Get,
   Post,
   Put,
@@ -66,5 +67,42 @@ export class MyController {
       req.user,
     );
     return res.status(serviceResult.code).json(serviceResult.message);
+  }
+
+  @Post('resume')
+  async createResume(@Body() resume, @Req() req, @Res() res: Response) {
+    const serviceResult: ServiceResult = await this.myService.createResume(
+      resume,
+      req.user,
+    );
+    return res.status(serviceResult.code).json(serviceResult.message);
+  }
+
+  @Put('resume')
+  async modifyResume(@Body() resume, @Req() req, @Res() res: Response) {
+    const serviceResult: ServiceResult = await this.myService.modifyResume(
+      resume,
+      req.user,
+    );
+    return res.status(serviceResult.code).json(serviceResult.message);
+  }
+
+  @Delete('resume')
+  async deleteResume(@Body() body, @Req() req, @Res() res: Response) {
+    const serviceResult: ServiceResult = await this.myService.deleteResume(
+      body.resumeId,
+      req.user,
+    );
+    return res.status(serviceResult.code).json(serviceResult.message);
+  }
+
+  @Get('resume')
+  async getResume(@Req() req, @Res() res: Response) {
+    const serviceResult: ServiceResult = await this.myService.getResume(
+      req.user,
+    );
+    if (serviceResult.code === 200)
+      return res.status(200).json(serviceResult.data);
+    else return res.status(serviceResult.code).json(serviceResult.message);
   }
 }

--- a/src/my/my.module.ts
+++ b/src/my/my.module.ts
@@ -1,9 +1,12 @@
 import { Module } from '@nestjs/common';
 import { AuthModule } from 'src/auth/auth.module';
 import { TypeOrmExModule } from 'src/lib/typeorm-ex.module';
+import { CareerRepository } from 'src/repository/carrer.repository';
 import { CountryRepository } from 'src/repository/country.repository';
 import { IndustryRepository } from 'src/repository/industry.repository';
+import { LanguageRepository } from 'src/repository/language.repository';
 import { RecruitRepository } from 'src/repository/recruit.repository';
+import { ResumeRepository } from 'src/repository/resume.repository';
 import { UserRepository } from 'src/repository/user.repository';
 import { MyController } from './my.controller';
 import { MyService } from './my.service';
@@ -14,6 +17,10 @@ import { MyService } from './my.service';
     TypeOrmExModule.forCustomRepository([CountryRepository]),
     TypeOrmExModule.forCustomRepository([IndustryRepository]),
     TypeOrmExModule.forCustomRepository([UserRepository]),
+    TypeOrmExModule.forCustomRepository([ResumeRepository]),
+    TypeOrmExModule.forCustomRepository([CareerRepository]),
+    TypeOrmExModule.forCustomRepository([LanguageRepository]),
+
     AuthModule,
   ],
   controllers: [MyController],

--- a/src/my/my.service.ts
+++ b/src/my/my.service.ts
@@ -1,21 +1,33 @@
 import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
 import RecruitDto from 'src/dto/recruit.dto';
+import ResumeDto from 'src/dto/resume.dto';
 import UserDto from 'src/dto/user.dto';
+import Career from 'src/entity/career.entity';
 import Country from 'src/entity/country.entity';
 import Industry from 'src/entity/industry.entity';
+import Language from 'src/entity/language.entity';
+import Resume from 'src/entity/resume.entity';
 import User from 'src/entity/user.entity';
+import { dataSource } from 'src/lib/dataSourse';
 import { PayType, UserType } from 'src/lib/enumeration/enum';
 import ServiceResult from 'src/lib/serviceResult';
+import { CareerRepository } from 'src/repository/carrer.repository';
 import { CountryRepository } from 'src/repository/country.repository';
 import { IndustryRepository } from 'src/repository/industry.repository';
+import { LanguageRepository } from 'src/repository/language.repository';
 import { RecruitRepository } from 'src/repository/recruit.repository';
+import { ResumeRepository } from 'src/repository/resume.repository';
 import { UserRepository } from 'src/repository/user.repository';
+import { In } from 'typeorm';
 
 @Injectable()
 export class MyService {
   constructor(
     private userRepository: UserRepository,
     private recruitRepository: RecruitRepository,
+    private resumeRepository: ResumeRepository,
+    private careerRepository: CareerRepository,
+    private languageRepository: LanguageRepository,
     private countryRepository: CountryRepository,
     private industryRepository: IndustryRepository,
   ) {}
@@ -210,6 +222,189 @@ export class MyService {
       const serviceResult: ServiceResult = {
         code: 200,
         message: 'Success!',
+      };
+      return serviceResult;
+    } catch (error) {
+      throw new HttpException(error, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+  }
+
+  async createResume(resumeDto: ResumeDto, user: User): Promise<ServiceResult> {
+    try {
+      if (user.userType !== UserType.person) {
+        const serviceResult: ServiceResult = {
+          code: 400,
+          message: '권한이 없습니다',
+        };
+        return serviceResult;
+      }
+      const industries: Industry[] = await this.industryRepository
+        .createQueryBuilder()
+        .where('id In (:id)', { id: resumeDto.desiredIndustry })
+        .getMany();
+
+      const countries: Country[] = await this.countryRepository
+        .createQueryBuilder()
+        .where('id In (:id)', { id: resumeDto.desiredCountry })
+        .getMany();
+
+      const careers: Career[] = await this.careerRepository
+        .createQueryBuilder('career')
+        .leftJoinAndSelect('career.person', 'user')
+        .where('career.id In (:id)', { id: resumeDto.career })
+        .andWhere('career.person = :a', { a: user.id })
+        .getMany();
+
+      const languages: Language[] = await this.languageRepository
+        .createQueryBuilder('language')
+        .leftJoinAndSelect('language.person', 'user')
+        .where('language.id In (:id)', { id: resumeDto.language })
+        .andWhere('language.person = :a', { a: user.id })
+        .getMany();
+
+      const newResume = await new Resume();
+      newResume.person = user;
+      newResume.catchPhrase = resumeDto.catchphrase;
+      newResume.introduction = resumeDto.introduction;
+      newResume.desiredIndustry = industries;
+      newResume.desiredCountry = countries;
+      newResume.desiredLocation = resumeDto.desiredLocation;
+      newResume.desiredPay = resumeDto.desiredPay;
+      newResume.public = resumeDto.public;
+      newResume.career = careers;
+      newResume.language = languages;
+
+      await this.resumeRepository.manager.save(newResume);
+      const serviceResult: ServiceResult = {
+        code: 200,
+        message: 'Success!',
+      };
+      return serviceResult;
+    } catch (error) {
+      throw new HttpException(error, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+  }
+
+  async modifyResume(resumeDto: ResumeDto, user: User): Promise<ServiceResult> {
+    try {
+      const myResume = await this.resumeRepository.findOne({
+        relations: { person: true },
+        where: { id: resumeDto.resumeId },
+      });
+      if (!myResume) {
+        const serviceResult: ServiceResult = {
+          code: 400,
+          message: '존재하지 않는 recruitId입니다.',
+        };
+        return serviceResult;
+      }
+      if (user.userType !== UserType.person || myResume.person.id !== user.id) {
+        const serviceResult: ServiceResult = {
+          code: 400,
+          message: '권한이 없습니다',
+        };
+        return serviceResult;
+      }
+      const industries: Industry[] = await this.industryRepository
+        .createQueryBuilder()
+        .where('id In (:id)', { id: resumeDto.desiredIndustry })
+        .getMany();
+
+      const countries: Country[] = await this.countryRepository
+        .createQueryBuilder()
+        .where('id In (:id)', { id: resumeDto.desiredCountry })
+        .getMany();
+
+      const careers: Career[] = await this.careerRepository
+        .createQueryBuilder('career')
+        .leftJoinAndSelect('career.person', 'user')
+        .where('career.id In (:id)', { id: resumeDto.career })
+        .andWhere('career.person = :a', { a: user.id })
+        .getMany();
+
+      const languages: Language[] = await this.languageRepository
+        .createQueryBuilder('language')
+        .leftJoinAndSelect('language.person', 'user')
+        .where('language.id In (:id)', { id: resumeDto.language })
+        .andWhere('language.person = :a', { a: user.id })
+        .getMany();
+
+      const newResume = await new Resume();
+      newResume.id = resumeDto.resumeId;
+      newResume.person = user;
+      newResume.catchPhrase = resumeDto.catchphrase;
+      newResume.introduction = resumeDto.introduction;
+      newResume.desiredIndustry = industries;
+      newResume.desiredCountry = countries;
+      newResume.desiredLocation = resumeDto.desiredLocation;
+      newResume.desiredPay = resumeDto.desiredPay;
+      newResume.public = resumeDto.public;
+      newResume.career = careers;
+      newResume.language = languages;
+
+      await this.resumeRepository.manager.save(newResume);
+
+      const serviceResult: ServiceResult = {
+        code: 200,
+        message: 'Success!',
+      };
+      return serviceResult;
+    } catch (error) {
+      throw new HttpException(error, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+  }
+
+  async deleteResume(resumeId: number, user: User): Promise<ServiceResult> {
+    try {
+      const myResume = await this.resumeRepository.findOne({
+        relations: { person: true },
+        where: { id: resumeId },
+      });
+
+      if (!myResume) {
+        const serviceResult: ServiceResult = {
+          code: 400,
+          message: '존재하지 않는 recruitId입니다.',
+        };
+        return serviceResult;
+      }
+      if (user.userType !== UserType.person || myResume.person.id !== user.id) {
+        const serviceResult: ServiceResult = {
+          code: 400,
+          message: '권한이 없습니다',
+        };
+        return serviceResult;
+      }
+
+      await this.resumeRepository.delete(resumeId);
+
+      const serviceResult: ServiceResult = {
+        code: 200,
+        message: 'Success!',
+      };
+      return serviceResult;
+    } catch (error) {
+      throw new HttpException(error, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+  }
+
+  async getResume(user: User): Promise<ServiceResult> {
+    try {
+      const myResume = await this.resumeRepository
+        .createQueryBuilder('resume')
+        .leftJoinAndSelect('resume.person', 'user')
+        .leftJoinAndSelect('resume.desiredCountry', 'country')
+        .leftJoinAndSelect('resume.desiredIndustry', 'industry')
+        .leftJoinAndSelect('resume.career', 'career')
+        .leftJoinAndSelect('resume.language', 'language')
+        .where('resume.person = :a', { a: user.id })
+        .getMany();
+
+      console.log(myResume);
+      const serviceResult: ServiceResult = {
+        code: 200,
+        message: 'Success!',
+        data: [myResume],
       };
       return serviceResult;
     } catch (error) {


### PR DESCRIPTION
POST(/my/resume)
{
    "catchPhrase": "hi",
    "introduction": "hellow",
    "desiredIndustry": [1],
    "desiredCountry": [1, 2],
    "career": [1],
    "public": true
}

PUT(/my/resume)
{
    "id": 7,
    "catchPhrase": "hi",
    "introduction": "hello",
    "desiredIndustry": [1],
    "desiredCountry": [1,3],
    "career": [1],
    "language": [1,2]
    "public": true
}

+) ManyToMany로 career, language, resume entity 수정함